### PR TITLE
macOS arm64 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ You can add this library to your project using JitPack.
 1. **Minimum JDK Version:** JDK 23
 2. **Supported Platforms:**
 
-| Platform | Architecture |
-|----------|--------------|
-| Windows  | x86_64       |
-| Linux    | x86_64       |
-| macOS    | x86_64       |
+| Platform | Architecture  |
+|----------|---------------|
+| Windows  | x86_64        |
+| Linux    | x86_64        |
+| macOS    | arm64, x86_64 |
 
 ### Gradle (Kotlin DSL)
 

--- a/src/main/java/com/github/fastnoise/FastNoise.java
+++ b/src/main/java/com/github/fastnoise/FastNoise.java
@@ -190,7 +190,7 @@ public class FastNoise implements AutoCloseable {
     }
 
     private static String determineDylibSuffix() {
-        if (OS.startsWith("darwin")) {
+        if (OS.startsWith("mac") || OS.startsWith("darwin")) {
             return ".dylib";
         } else if (OS.startsWith("win")) {
             return ".dll";


### PR DESCRIPTION
Built FastNoise shared library for macOS on arm64 M1+ chips.
Also fixed how extension of shared library determined (OS value was "mac os x", not "darwin")

Tested on my M3 machine, seems to work fine.